### PR TITLE
updated mathjax CDN

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,6 +16,6 @@
     {% include footer.html %}
 
     <!-- mathjax -->
-    <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     </body>
 </html>


### PR DESCRIPTION
MathJax self hosted CDN has been taken down. Updated the CDN to https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML
Reference:
https://www.mathjax.org/cdn-shutting-down/